### PR TITLE
change gradient title text to a flat green color

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -56,10 +56,7 @@ body {
   font-size: 2rem;
   font-weight: 700;
   letter-spacing: -0.02em;
-  background: linear-gradient(135deg, var(--color-x), var(--color-o));
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  color: #22c55e;
 }
 
 .app__main {


### PR DESCRIPTION
Successfully changed the gradient title text to a flat green color. Modified the  CSS class in  by removing the linear gradient background and text clipping properties, replacing them with a simple green color (#22c55e). The title "Tic Tac Toe" will now display in a flat green color instead of the previous gradient effect.